### PR TITLE
Making the CyCL configuration more meaningful to other apps

### DIFF
--- a/src/main/java/org/cytoscape/opencl/cycl/CyCL.java
+++ b/src/main/java/org/cytoscape/opencl/cycl/CyCL.java
@@ -23,8 +23,22 @@ public class CyCL
 	private static List<CyCLDevice> devices = new ArrayList<>();
 	private static boolean isInitialized = false;
 	
+	private static CyProperty<Properties> propertyService;
+	
 	public CyCL()
 	{
+	}
+	
+	public static CyCLDevice getPreferredDevice()
+	{
+		if (devices == null || devices.isEmpty())
+		{
+			return null;
+		}
+		else
+		{
+			return devices.get(0);
+		}
 	}
 	
 	public static List<CyCLDevice> getDevices()
@@ -33,6 +47,26 @@ public class CyCL
 			devices = new ArrayList<>();
 		
 		return devices;
+	}
+	
+	/**
+	 * Apps that run prolonged computations should check this flag, if it is true, any prolonged computations
+	 * should be split into smaller parts to prevent 100% occupation of the device. This is mostly useful for users
+	 * than run OpenCL computations on the same GPU that powers their display, since fully occupying such a GPU 
+	 * may lead to system freeze and/or the computation may be terminated (as with Timeout Detection Recovery on Windows).
+	 * @return
+	 */
+	public static boolean isPreventFullOccupation()
+	{
+		String preventOccupationString = propertyService.getProperties().getProperty(CyCLSettings.PREVENT_FULL_OCCUPATION);
+		if (preventOccupationString == null)
+		{
+			return false;
+		}
+		else
+		{
+			return Boolean.parseBoolean(preventOccupationString);
+		}
 	}
 	
 	/**
@@ -49,7 +83,9 @@ public class CyCL
 		{
 			if (isInitialized)
 				return true;
-					
+			
+			CyCL.propertyService = propertyService;
+			
 			File configDir = applicationConfig.getConfigurationDirectoryLocation();
 			String dummyPath = configDir.getAbsolutePath() + File.separator + "disable-opencl.dummy";
 			
@@ -70,7 +106,7 @@ public class CyCL
 				
 					// Populate device list
 					Properties globalProps = propertyService.getProperties();
-					String preferredDevice = globalProps.getProperty("opencl.device.preferred");
+					String preferredDevice = globalProps.getProperty(CyCLSettings.PREFERREDNAME);
 					
 					if (preferredDevice == null)
 						preferredDevice = "";

--- a/src/main/java/org/cytoscape/opencl/cycl/CyCLDevice.java
+++ b/src/main/java/org/cytoscape/opencl/cycl/CyCLDevice.java
@@ -35,7 +35,14 @@ public class CyCLDevice
 	
 	public String platformName;
 	
+	/**
+	 * A unique identifier valid only in CyCL - it is the combination of {{@link #version} and {@link #openCLName}.
+	 */
 	public final String name;
+	/**
+	 * The name of the device as reported by the OpenCL API
+	 */
+	public final String openCLName;
 	public final String vendor;
 	public final String version;
 	public final DeviceTypes type;
@@ -99,6 +106,7 @@ public class CyCLDevice
 		vendor = device.getInfoString(CL10.CL_DEVICE_VENDOR);
 		version = device.getInfoString(CL10.CL_DEVICE_VERSION);
 		name = version + " " + device.getInfoString(CL10.CL_DEVICE_NAME);
+		openCLName = device.getInfoString(CL10.CL_DEVICE_NAME);
 		
 		// Device type can be in theory a combination of multiple enum values, GPU is probably the most important indicator
 		long longType = device.getInfoLong(CL10.CL_DEVICE_TYPE);

--- a/src/main/java/org/cytoscape/opencl/cycl/CyCLSettings.java
+++ b/src/main/java/org/cytoscape/opencl/cycl/CyCLSettings.java
@@ -1,0 +1,13 @@
+package org.cytoscape.opencl.cycl;
+
+/**
+ * Defines keys for settings of the CyCL app.
+ * @author MBU
+ *
+ */
+public class CyCLSettings {
+	static final String PREFERREDNAME = "opencl.device.preferred";
+	static final String PREVENT_FULL_OCCUPATION = "opencl.device.preventFullOccupation";
+
+	
+}


### PR DESCRIPTION
Following the proposals mentioned at https://groups.google.com/forum/#!topic/cytoscape-app-dev/23ViR1piyGE CyCL now exposes the exact name of devices. This can be used to identify the preferred device when calling OpenCL through other library than CyCL.

Further, the user may tick that they want to "prevent full occupation" of the preferred device - apps using OpenCL may honor this option and split the workload in smaller chunks, if selected. The option is useful when performing computations on the same GPU that runs the main display of the system to prevent the system from freezing.